### PR TITLE
fix update mci status error

### DIFF
--- a/pkg/controllers/multiclusteringress/mci_controller.go
+++ b/pkg/controllers/multiclusteringress/mci_controller.go
@@ -155,7 +155,7 @@ func (c *MCIController) updateMCIStatus(ctx context.Context, mci *networkingv1al
 		}
 
 		updated := &networkingv1alpha1.MultiClusterIngress{}
-		if err = c.Get(ctx, client.ObjectKey{Namespace: mci.Namespace, Name: mci.Name}, updated); err != nil {
+		if err = c.Get(ctx, client.ObjectKey{Namespace: mci.Namespace, Name: mci.Name}, updated); err == nil {
 			mci = updated
 		} else {
 			klog.Errorf("Failed to get updated multiClusterIngress(%s/%s): %v", mci.Namespace, mci.Name, err)


### PR DESCRIPTION
In the `updateMCIStatus` logic, we will update MCI status with RetryOnConflict method, when we update failed, we will get the latest object in the system, but in the process, we make a mistake:

https://github.com/karmada-io/multicluster-cloud-provider/blob/f7fa870be3a470b437c42aff3f166575ec843fff/pkg/controllers/multiclusteringress/mci_controller.go#L158

This patch update this error.

/kind bug