### PR TITLE
watch secret event for mci object

### DIFF
--- a/app/manager.go
+++ b/app/manager.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	multiclusterprovider "github.com/karmada-io/multicluster-cloud-provider"
@@ -150,9 +151,7 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, cloudP
 
 	controlPlaneInformerManager := genericmanager.NewSingleClusterInformerManager(dynamicClientSet, 0, ctx.Done())
 
-	if err := indexes.SetupIndexesForMCI(ctx, mgr.GetFieldIndexer()); err != nil {
-		klog.Fatalf("failed to setup indexes for MultiClusterIngress object: %v", err)
-	}
+	setupIndexesForMCI(ctx, mgr.GetFieldIndexer())
 
 	controllerCtx := controllersctx.Context{
 		Context:       ctx,
@@ -175,4 +174,14 @@ func setupControllers(ctx context.Context, mgr controllerruntime.Manager, cloudP
 		<-ctx.Done()
 		genericmanager.StopInstance()
 	}()
+}
+
+func setupIndexesForMCI(ctx context.Context, fieldIndexer client.FieldIndexer) {
+	if err := indexes.SetupServiceIndexesForMCI(ctx, fieldIndexer); err != nil {
+		klog.Fatalf("failed to setup service indexes for MultiClusterIngress object: %v", err)
+	}
+
+	if err := indexes.SetupSecretIndexesForMCI(ctx, fieldIndexer); err != nil {
+		klog.Fatalf("failed to setup secret indexes for MultiClusterIngress object: %v", err)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When setting the TLS field for an MCI object, it involves Secret resources, so the `multiclusteringress-controller` needs to watch events related to secrets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
multiclusteringress-controller: watch secret event for mci object
```

