### PR TITLE
Update tolerate forever with serviceexport crd

### DIFF
--- a/pkg/controllers/crdinstallation/crd_installation_controller.go
+++ b/pkg/controllers/crdinstallation/crd_installation_controller.go
@@ -6,6 +6,7 @@ import (
 	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
 	policyv1alpha1 "github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
 	"github.com/karmada-io/karmada/pkg/sharedcli/ratelimiterflag"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -144,7 +145,20 @@ func clusterPropagationPolicy(clusters []string) *policyv1alpha1.ClusterPropagat
 			Placement: policyv1alpha1.Placement{
 				ClusterAffinity: &policyv1alpha1.ClusterAffinity{
 					ClusterNames: clusters,
-				}}}}
+				},
+				ClusterTolerations: []corev1.Toleration{
+					{
+						Key:      clusterv1alpha1.TaintClusterNotReady,
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoExecute,
+					},
+					{
+						Key:      clusterv1alpha1.TaintClusterUnreachable,
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoExecute,
+					},
+				},
+			}}}
 }
 
 // SetupWithManager creates a controller and register to controller manager.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

When a Cluster turns into failed, it will trigger failover. As a result, the ServiceExport CRD will be deleted when the cluster recovers, this action is not expected. So I updated the CPP tolerate to forever.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

