### PR TITLE
feat:structured logging

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -9,6 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/component-base/featuregate"
+	logsapi "k8s.io/component-base/logs/api/v1"
 )
 
 const (
@@ -57,6 +59,10 @@ type MultiClusterControllerManagerOptions struct {
 
 	RateLimiterOpts ratelimiterflag.Options
 	ProfileOpts     profileflag.Options
+	// Logging contains logging options.
+	Logging *logsapi.LoggingConfiguration
+	// FeatureGate is a shared global feature gate used for parsing command-line arguments.
+	FeatureGate featuregate.MutableFeatureGate
 }
 
 // NewClusterControllerManagerOptions builds an empty MultiClusterControllerManagerOptions.
@@ -68,6 +74,7 @@ func NewClusterControllerManagerOptions() *MultiClusterControllerManagerOptions 
 			ResourceNamespace: NamespaceKarmadaSystem,
 			ResourceName:      "multicluster-controller-manager",
 		},
+		Logging: logsapi.NewLoggingConfiguration(),
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/karmada-io/multicluster-cloud-provider/issues/26

**Special notes for your reviewer**:

You can use logging-format like below
```
multicluster-cloud-provider % ./controller-manager --logging-format=json --multicluster-provider=fake --provider-ingress-class=fake
{"ts":1766906188213.9038,"caller":"app/manager.go:104","msg":"multicluster-controller-manager version: version.Info{GitVersion:\"v0.0.0-master\", GitCommit:\"unknown\", GitShortCommit:\"unknown\", GitTreeState:\"unknown\", BuildDate:\"unknown\", GoVersion:\"go1.25.1\", Compiler:\"gc\", Platform:\"darwin/arm64\"}","v":0}
{"ts":1766906188216.369,"caller":"cluster/cluster.go:170","msg":"Failed to get API Group-Resources","err":"Get \"https://127.0.0.1:64753/api?timeout=32s\": dial tcp 127.0.0.1:64753: connect: connection refused"}
{"ts":1766906188216.387,"caller":"app/manager.go:137","msg":"Failed to build controller manager: Get \"https://127.0.0.1:64753/api?timeout=32s\": dial tcp 127.0.0.1:64753: connect: connection refused"}
{"ts":1766906188216.395,"caller":"cli/run.go:72","msg":"command failed","err":"Get \"https://127.0.0.1:64753/api?timeout=32s\": dial tcp 127.0.0.1:64753: connect: connection refused"}
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

